### PR TITLE
Missing usage of C build system module

### DIFF
--- a/sfml-window/build/root.build
+++ b/sfml-window/build/root.build
@@ -1,6 +1,7 @@
 cxx.std = latest
 
 using cxx
+using c
 
 hxx{*}: extension = hpp
 ixx{*}: extension = ipp


### PR DESCRIPTION
The CI error points to missing target type `c` which is provided by the `c` build-system module but was not used here.