### PR TITLE
Various Windows build fixes

### DIFF
--- a/sfml-graphics/src/buildfile
+++ b/sfml-graphics/src/buildfile
@@ -57,7 +57,7 @@ lib{sfml-graphics}:
   cxx.export.libs = $intf_libs $platform_libs
 }
 
-liba{sfml-graphics}: cxx.export.poptions += -DSFML_GRAPHICS_STATIC
+liba{sfml-graphics}: cxx.export.poptions += -DSFML_GRAPHICS_STATIC -DSFML_STATIC
 libs{sfml-graphics}: cxx.export.poptions += -DSFML_GRAPHICS_SHARED
 
 # For pre-releases use the complete version to make sure they cannot be used

--- a/sfml-network/src/buildfile
+++ b/sfml-network/src/buildfile
@@ -52,7 +52,7 @@ lib{sfml-network}:
   cxx.export.libs = $intf_libs $platform_libs
 }
 
-liba{sfml-network}: cxx.export.poptions += -DSFML_WINDOW_STATIC
+liba{sfml-network}: cxx.export.poptions += -DSFML_WINDOW_STATIC -DSFML_STATIC
 libs{sfml-network}: cxx.export.poptions += -DSFML_WINDOW_SHARED
 
 # For pre-releases use the complete version to make sure they cannot be used

--- a/sfml-system/src/buildfile
+++ b/sfml-system/src/buildfile
@@ -69,7 +69,7 @@ lib{sfml-system}:
   cxx.export.libs = $intf_libs
 }
 
-liba{sfml-system}: cxx.export.poptions += -DSFML_SYSTEM_STATIC
+liba{sfml-system}: cxx.export.poptions += -DSFML_SYSTEM_STATIC -DSFML_STATIC
 libs{sfml-system}: cxx.export.poptions += -DSFML_SYSTEM_SHARED
 
 # For pre-releases use the complete version to make sure they cannot be used

--- a/sfml-window/src/buildfile
+++ b/sfml-window/src/buildfile
@@ -41,13 +41,7 @@ switch $config.sfml_window.platform
     {
         lib{sfml-window}: SFML/Window/Win32/{hxx cxx}{*}
         platform_poptions += -DUNICODE -D_UNICODE
-        switch $cxx.id
-        {
-            case 'msvc'
-                platform_libs += winmm.lib gdi32.lib opengl32.lib advapi32.lib
-            default
-                platform_libs += -lwinmm -lgdi32 -lopengl32 -ladvapi32
-        }
+        platform_libs += winmm.lib gdi32.lib opengl32.lib advapi32.lib
     }
     case 'linux'
     {

--- a/sfml-window/src/buildfile
+++ b/sfml-window/src/buildfile
@@ -164,7 +164,7 @@ lib{sfml-window}:
   cxx.export.libs = $intf_libs $platform_libs
 }
 
-liba{sfml-window}: cxx.export.poptions += -DSFML_WINDOW_STATIC
+liba{sfml-window}: cxx.export.poptions += -DSFML_WINDOW_STATIC -DSFML_STATIC
 libs{sfml-window}: cxx.export.poptions += -DSFML_WINDOW_SHARED
 
 # For pre-releases use the complete version to make sure they cannot be used


### PR DESCRIPTION

## 1 Fixed user code importing symbols even if using static versions of the libraries

Both the static libraries code and their users should have `SFML_STATIC` set,
not only the libraries.
See:
https://github.com/SFML/SFML/blob/2f11710abc5aa478503a7ff3f9e654bd2078ebab/cmake/Macros.cmake#L180
which sets it as public.

Also: https://github.com/SFML/SFML/blob/2f11710abc5aa478503a7ff3f9e654bd2078ebab/include/SFML/Config.hpp#L122
Nothing should be done symbol-wise with static libraries,
whatever the platform, on both sides.

## 2 Clang on Windows don't need to use `-lsomelib` syntax

When using clang on windows, one just needs to use the same `*.cxx.libs += somesystemlib.lib` syntax whatever the compiler.
This is because currently using clang will use the toolchain of msvc, including the linker, so any linker flag still needs to be msvc's linker syntax (see details [there](https://build2.org/build2/doc/build2-build-system-manual.xhtml#cc-clang-msvc))
Without this fix the flags were simply ignored and link errors because of missing symbols prevented the build.
