### PR TITLE
Fix conditional prerequisites

### DIFF
--- a/libsfml-graphics/src/buildfile
+++ b/libsfml-graphics/src/buildfile
@@ -12,6 +12,7 @@ pub_hdrs = $($pub/ pub_hdrs)
 
 lib{sfml-graphics}: $pub/{$pub_hdrs}
 lib{sfml-graphics}: SFML/Graphics/{hxx cxx}{* -GLLoader} $intf_libs
+lib{sfml-graphics}: SFML/Graphics/{hxx cxx}{GLLoader}: include = (!$config.libsfml_graphics.use_opengles)
 
 platform_libs =
 if($config.libsfml_graphics.use_opengles)
@@ -27,12 +28,12 @@ if($config.libsfml_graphics.use_opengles)
 }
 else
 {
-    lib{sfml-graphics}: SFML/Graphics/{hxx cxx}{GLLoader}
     if($config.libsfml_graphics.platform == 'linux')
     {
         platform_libs += -lX11
     }
 }
+
 
 # Build options.
 out_pfx_inc = [dir_path] $out_root/include/

--- a/libsfml-network/src/buildfile
+++ b/libsfml-network/src/buildfile
@@ -7,13 +7,13 @@ include $pub
 
 pub_hdrs = $($pub/ pub_hdrs)
 
-is_windows = ($config.libsfml_system.platform == 'windows')
-is_unix = ($config.libsfml_system.platform == 'linux' || \
-          $config.libsfml_system.platform == 'macos' || \
-          $config.libsfml_system.platform == 'freebsd' || \
-          $config.libsfml_system.platform == 'openbsd' || \
-          $config.libsfml_system.platform == 'android' || \
-          $config.libsfml_system.platform == 'ios')
+is_windows = ($config.libsfml_network.platform == 'windows')
+is_unix = ($config.libsfml_network.platform == 'linux' || \
+          $config.libsfml_network.platform == 'macos' || \
+          $config.libsfml_network.platform == 'freebsd' || \
+          $config.libsfml_network.platform == 'openbsd' || \
+          $config.libsfml_network.platform == 'android' || \
+          $config.libsfml_network.platform == 'ios')
 
 lib{sfml-network}: $pub/{$pub_hdrs}
 lib{sfml-network}: SFML/Network/{hxx cxx}{*} $intf_libs

--- a/libsfml-network/src/buildfile
+++ b/libsfml-network/src/buildfile
@@ -7,29 +7,26 @@ include $pub
 
 pub_hdrs = $($pub/ pub_hdrs)
 
+is_windows = ($config.libsfml_system.platform == 'windows')
+is_unix = ($config.libsfml_system.platform == 'linux' || \
+          $config.libsfml_system.platform == 'macos' || \
+          $config.libsfml_system.platform == 'freebsd' || \
+          $config.libsfml_system.platform == 'openbsd' || \
+          $config.libsfml_system.platform == 'android' || \
+          $config.libsfml_system.platform == 'ios')
+
 lib{sfml-network}: $pub/{$pub_hdrs}
 lib{sfml-network}: SFML/Network/{hxx cxx}{*} $intf_libs
+lib{sfml-network}: SFML/Network/Win32/{hxx cxx}{*}: include = $is_windows
+lib{sfml-network}: SFML/Network/Unix/{hxx cxx}{*}: include = $is_unix
 
 platform_libs =
-switch $config.libsfml_network.platform
+if ($config.libsfml_network.platform == 'windows')
 {
-    case 'windows'
-    {
-        lib{sfml-network}: SFML/Network/Win32/{hxx cxx}{*}
-        if ($cxx.target.system == 'mingw32')
-            platform_libs += -lws2_32
-        else
-            platform_libs += ws2_32.lib
-    }
-    case 'linux'
-    case 'openbsd'
-    case 'freebsd'
-    case 'macos'
-    case 'ios'
-    case 'android'
-        lib{sfml-network}: SFML/Network/Unix/{hxx cxx}{*}
-    default
-        fail 'Invalid SFML platform'
+    if ($cxx.target.system == 'mingw32')
+        platform_libs += -lws2_32
+    else
+        platform_libs += ws2_32.lib
 }
 
 # Build options.

--- a/libsfml-system/src/buildfile
+++ b/libsfml-system/src/buildfile
@@ -5,8 +5,20 @@ include $pub
 
 pub_hdrs = $($pub/ pub_hdrs)
 
+is_windows = ($config.libsfml_system.platform == 'windows')
+is_android = ($config.libsfml_system.platform == 'android')
+is_unix = ($config.libsfml_system.platform == 'linux' || \
+          $config.libsfml_system.platform == 'macos' || \
+          $config.libsfml_system.platform == 'freebsd' || \
+          $config.libsfml_system.platform == 'openbsd' || \
+          $config.libsfml_system.platform == 'android' || \
+          $config.libsfml_system.platform == 'ios')
+
 lib{sfml-system}: $pub/{$pub_hdrs}
 lib{sfml-system}: SFML/System/{hxx cxx}{*}
+lib{sfml-system}: SFML/System/Win32/{hxx cxx}{*}: include = $is_windows
+lib{sfml-system}: SFML/System/Unix/{hxx cxx}{*}: include = $is_unix
+lib{sfml-system}: SFML/System/Android/{hxx cxx}{*}: include = $is_android
 
 platform_libs = # Platform specific libraries.
 platform_poptions = # Platform specific poptions.
@@ -14,7 +26,6 @@ switch $config.libsfml_system.platform
 {
     case 'windows'
     {
-        lib{sfml-system}: SFML/System/Win32/{hxx cxx}{*}
         if ($cxx.target.system == 'mingw32')
             platform_libs += -lwinmm
         else
@@ -22,27 +33,17 @@ switch $config.libsfml_system.platform
     }
     case 'linux'
     {
-        lib{sfml-system}: SFML/System/Unix/{hxx cxx}{*}
         platform_libs = -lpthread -lrt
     }
     case 'macos'
     case 'openbsd'
     {
-        lib{sfml-system}: SFML/System/Unix/{hxx cxx}{*}
         platform_libs = -lpthread
     }
-    case 'ios'
-    case 'freebsd'
-    case 'netbsd'
-        lib{sfml-system}: SFML/System/Unix/{hxx cxx}{*}
     case 'android'
     {
-        lib{sfml-system}: SFML/System/Unix/{hxx cxx}{*}
-        lib{sfml-system}: SFML/System/Android/{hxx cxx}{*}
         platform_libs = -landroid -llog
     }
-    default
-        fail 'Invalid SFML platform'
 }
 
 # Build options.

--- a/libsfml-window/src/buildfile
+++ b/libsfml-window/src/buildfile
@@ -24,10 +24,107 @@ lib{sfml-window}: SFML/Window/Win32/{hxx cxx}{*}: include = $is_windows
 lib{sfml-window}: SFML/Window/Unix/{hxx cxx}{JoystickImpl}: include = $is_linux
 lib{sfml-window}: SFML/Window/OpenBSD/{hxx cxx}{*}: include = $is_openbsd
 lib{sfml-window}: SFML/Window/FreeBSD/{hxx cxx}{*}: include = $is_freebsd
-lib{sfml-window}: SFML/Window/OSX/{h hxx cxx}{*}: include = $is_macos
 lib{sfml-window}: SFML/Window/iOS/{hxx cxx}{*}: include = $is_ios
 lib{sfml-window}: SFML/Window/Unix/{hxx cxx}{* -JoystickImpl -GlxContext}: include = $is_android
 lib{sfml-window}: SFML/Window/Android/{hxx cxx}{*}: include = $is_android
+
+# MacOS
+# =====
+lib{sfml-window}: SFML/Window/OSX/{h hxx cxx}{*}: include = $is_macos
+
+define mm: file
+mm{*}: extension = mm
+
+define m: file
+m{*}: extension = m
+
+objc_files = SFML/Window/OSX/*.m
+objc_files = $regex.apply($objc_files,'(.+)\.m','\1')
+
+objcxx_files = SFML/Window/OSX/*.mm
+objcxx_files = $regex.apply($objcxx_files,'(.+)\.mm','\1')
+
+[rule_hint=cxx] libul{sfml-window-meta}: $intf_libs
+
+for n: $objc_files
+{
+    obja{$(n).a.o}: m{$n}: include = $is_macos
+    objs{$(n).so.o}: m{$n}: include = $is_macos
+}
+
+for n: $objcxx_files
+{
+    obja{$(n).a.o}: mm{$n}: include = $is_macos
+    objs{$(n).so.o}: mm{$n}: include = $is_macos
+}
+
+liba{sfml-window}: obja{$regex.apply($objc_files,'(.+)','\1.a.o')}: include = $is_macos
+libs{sfml-window}: objs{$regex.apply($objc_files,'(.+)','\1.so.o')}: include = $is_macos
+
+liba{sfml-window}: obja{$regex.apply($objcxx_files,'(.+)','\1.a.o')}: include = $is_macos
+libs{sfml-window}: objs{$regex.apply($objcxx_files,'(.+)','\1.so.o')}: include = $is_macos
+
+obja{~'/(.*).a/'}: mm{~'/\1/'} libua{sfml-window-meta}
+{{
+    dep_poptions = $cxx.lib_poptions(libua{sfml-window-meta}, obja)
+    depdb hash $dep_poptions
+    depdb dyndep "-I$out_root/src" "-I$src_root/src" \
+                 "-I$out_root/include" "-I$src_root/include" \
+                 --what=header --default-type=h \
+                 --update-exclude libua{sfml-window-meta} \
+                 -- $cxx.path $cc.poptions $cxx.poptions $dep_poptions \
+                    $cc.coptions $cxx.coptions $cxx.mode -M -MG $path($<[0])
+    diag obj-c++ ($<[0])
+    $cxx.path $cc.poptions $cxx.poptions $dep_poptions    \
+              $cc.coptions $cxx.coptions $cxx.mode        \
+              -o $path($>) -c -x objective-c++ $path($<[0])
+}}
+objs{~'/(.*).so/'}: mm{~'/\1/'} libus{sfml-window-meta}
+{{
+    dep_poptions = $cxx.lib_poptions(libus{sfml-window-meta}, objs)
+    depdb hash $dep_poptions
+    depdb dyndep "-I$out_root/src" "-I$src_root/src" \
+                 "-I$out_root/include" "-I$src_root/include" \
+                 --what=header --default-type=h \
+                 --update-exclude libus{sfml-window-meta} \
+                 -- $cxx.path $cc.poptions $cxx.poptions $dep_poptions \
+                    $cc.coptions $cxx.coptions $cxx.mode -M -MG $path($<[0])
+    diag obj-c++ ($<[0])
+    $cxx.path $cc.poptions $cxx.poptions $dep_poptions    \
+              $cc.coptions $cxx.coptions $cxx.mode        \
+              -o $path($>) -c -x objective-c++ $path($<[0])
+}}
+
+obja{~'/(.*).a/'}: m{~'/\1/'} libua{sfml-window-meta}
+{{
+    dep_poptions = $c.lib_poptions(libua{sfml-window-meta}, obja)
+    depdb hash $dep_poptions
+    depdb dyndep "-I$out_root/src" "-I$src_root/src" \
+                 "-I$out_root/include" "-I$src_root/include" \
+                 --what=header --default-type=h \
+                 --update-exclude libua{sfml-window-meta} \
+                 -- $c.path $cc.poptions $c.poptions $dep_poptions \
+                    $cc.coptions $c.coptions $c.mode -M -MG $path($<[0])
+    diag obj-c ($<[0])
+    $c.path $cc.poptions $c.poptions $dep_poptions    \
+              $cc.coptions $c.coptions $c.mode        \
+              -o $path($>) -c -x objective-c $path($<[0])
+}}
+objs{~'/(.*).so/'}: m{~'/\1/'} libus{sfml-window-meta}
+{{
+    dep_poptions = $c.lib_poptions(libus{sfml-window-meta}, objs)
+    depdb hash $dep_poptions
+    depdb dyndep "-I$out_root/src" "-I$src_root/src" \
+                 "-I$out_root/include" "-I$src_root/include" \
+                 --what=header --default-type=h \
+                 --update-exclude libus{sfml-window-meta} \
+                 -- $c.path $cc.poptions $c.poptions $dep_poptions \
+                    $cc.coptions $c.coptions $c.mode -M -MG $path($<[0])
+    diag obj-c ($<[0])
+    $c.path $cc.poptions $c.poptions $dep_poptions    \
+              $cc.coptions $c.coptions $c.mode        \
+              -o $path($>) -c -x objective-c $path($<[0])
+}}
 
 
 platform_libs = # Platform specific libraries.
@@ -63,101 +160,6 @@ switch $config.libsfml_window.platform
     }
     case 'macos'
     {
-
-        define mm: file
-        mm{*}: extension = mm
-
-        define m: file
-        m{*}: extension = m
-
-        objc_files = SFML/Window/OSX/*.m
-        objc_files = $regex.apply($objc_files,'(.+)\.m','\1')
-
-        objcxx_files = SFML/Window/OSX/*.mm
-        objcxx_files = $regex.apply($objcxx_files,'(.+)\.mm','\1')
-
-        [rule_hint=cxx] libul{sfml-window-meta}: $intf_libs
-
-        for n: $objc_files
-        {
-            obja{$(n).a.o}: m{$n}
-            objs{$(n).so.o}: m{$n}
-        }
-
-        for n: $objcxx_files
-        {
-            obja{$(n).a.o}: mm{$n}
-            objs{$(n).so.o}: mm{$n}
-        }
-
-        liba{sfml-window}: obja{$regex.apply($objc_files,'(.+)','\1.a.o')}
-        libs{sfml-window}: objs{$regex.apply($objc_files,'(.+)','\1.so.o')}
-
-        liba{sfml-window}: obja{$regex.apply($objcxx_files,'(.+)','\1.a.o')}
-        libs{sfml-window}: objs{$regex.apply($objcxx_files,'(.+)','\1.so.o')}
-
-        obja{~'/(.*).a/'}: mm{~'/\1/'} libua{sfml-window-meta}
-        {{
-            dep_poptions = $cxx.lib_poptions(libua{sfml-window-meta}, obja)
-            depdb hash $dep_poptions
-            depdb dyndep "-I$out_root/src" "-I$src_root/src" \
-                         "-I$out_root/include" "-I$src_root/include" \
-                         --what=header --default-type=h \
-                         --update-exclude libua{sfml-window-meta} \
-                         -- $cxx.path $cc.poptions $cxx.poptions $dep_poptions \
-                            $cc.coptions $cxx.coptions $cxx.mode -M -MG $path($<[0])
-            diag obj-c++ ($<[0])
-            $cxx.path $cc.poptions $cxx.poptions $dep_poptions    \
-                      $cc.coptions $cxx.coptions $cxx.mode        \
-                      -o $path($>) -c -x objective-c++ $path($<[0])
-        }}
-        objs{~'/(.*).so/'}: mm{~'/\1/'} libus{sfml-window-meta}
-        {{
-            dep_poptions = $cxx.lib_poptions(libus{sfml-window-meta}, objs)
-            depdb hash $dep_poptions
-            depdb dyndep "-I$out_root/src" "-I$src_root/src" \
-                         "-I$out_root/include" "-I$src_root/include" \
-                         --what=header --default-type=h \
-                         --update-exclude libus{sfml-window-meta} \
-                         -- $cxx.path $cc.poptions $cxx.poptions $dep_poptions \
-                            $cc.coptions $cxx.coptions $cxx.mode -M -MG $path($<[0])
-            diag obj-c++ ($<[0])
-            $cxx.path $cc.poptions $cxx.poptions $dep_poptions    \
-                      $cc.coptions $cxx.coptions $cxx.mode        \
-                      -o $path($>) -c -x objective-c++ $path($<[0])
-        }}
-
-        obja{~'/(.*).a/'}: m{~'/\1/'} libua{sfml-window-meta}
-        {{
-            dep_poptions = $c.lib_poptions(libua{sfml-window-meta}, obja)
-            depdb hash $dep_poptions
-            depdb dyndep "-I$out_root/src" "-I$src_root/src" \
-                         "-I$out_root/include" "-I$src_root/include" \
-                         --what=header --default-type=h \
-                         --update-exclude libua{sfml-window-meta} \
-                         -- $c.path $cc.poptions $c.poptions $dep_poptions \
-                            $cc.coptions $c.coptions $c.mode -M -MG $path($<[0])
-            diag obj-c ($<[0])
-            $c.path $cc.poptions $c.poptions $dep_poptions    \
-                      $cc.coptions $c.coptions $c.mode        \
-                      -o $path($>) -c -x objective-c $path($<[0])
-        }}
-        objs{~'/(.*).so/'}: m{~'/\1/'} libus{sfml-window-meta}
-        {{
-            dep_poptions = $c.lib_poptions(libus{sfml-window-meta}, objs)
-            depdb hash $dep_poptions
-            depdb dyndep "-I$out_root/src" "-I$src_root/src" \
-                         "-I$out_root/include" "-I$src_root/include" \
-                         --what=header --default-type=h \
-                         --update-exclude libus{sfml-window-meta} \
-                         -- $c.path $cc.poptions $c.poptions $dep_poptions \
-                            $cc.coptions $c.coptions $c.mode -M -MG $path($<[0])
-            diag obj-c ($<[0])
-            $c.path $cc.poptions $c.poptions $dep_poptions    \
-                      $cc.coptions $c.coptions $c.mode        \
-                      -o $path($>) -c -x objective-c $path($<[0])
-        }}
-
         platform_libs += -framework Cocoa \
                          -framework Foundation \
                          -framework CoreFoundation \

--- a/libsfml-window/src/buildfile
+++ b/libsfml-window/src/buildfile
@@ -48,14 +48,14 @@ objcxx_files = $regex.apply($objcxx_files,'(.+)\.mm','\1')
 
 for n: $objc_files
 {
-    obja{$(n).a.o}: m{$n}: include = $is_macos
-    objs{$(n).so.o}: m{$n}: include = $is_macos
+    obja{$(n).a.o}: m{$n}
+    objs{$(n).so.o}: m{$n}
 }
 
 for n: $objcxx_files
 {
-    obja{$(n).a.o}: mm{$n}: include = $is_macos
-    objs{$(n).so.o}: mm{$n}: include = $is_macos
+    obja{$(n).a.o}: mm{$n}
+    objs{$(n).so.o}: mm{$n}
 }
 
 liba{sfml-window}: obja{$regex.apply($objc_files,'(.+)','\1.a.o')}: include = $is_macos

--- a/libsfml-window/src/buildfile
+++ b/libsfml-window/src/buildfile
@@ -6,27 +6,29 @@ pub = [dir_path] ../include/
 include $pub
 pub_hdrs = $($pub/ pub_hdrs)
 
+is_ios = ($config.libsfml_window.platform == 'ios')
+is_android = ($config.libsfml_window.platform == 'android')
+is_windows = ($config.libsfml_window.platform == 'windows')
+is_linux = ($config.libsfml_window.platform == 'linux')
+is_openbsd = ($config.libsfml_window.platform == 'freebsd')
+is_freebsd = ($config.libsfml_window.platform == 'openbsd')
+is_macos = ($config.libsfml_window.platform == 'macos')
+is_linux_or_bsd = ($is_linux || $is_freebsd || $is_openbsd)
+
 lib{sfml-window}: $pub/{$pub_hdrs}
 lib{sfml-window}: SFML/Window/{hxx cxx}{* -EGLCheck -EglContext} $intf_libs
+lib{sfml-window}: SFML/Window/{hxx cxx}{EGLCheck EglContext}: include = (!$is_ios && $config.libsfml_window.use_opengles)
+lib{sfml-window}: SFML/Window/Unix/{hxx cxx}{* -JoystickImpl -GlxContext -GlxExtensions}: include = $is_linux_or_bsd
+lib{sfml-window}: SFML/Window/Unix/{hxx cxx}{GlxContext GlxExtensions} : include = ($is_linux_or_bsd && !$config.libsfml_window.use_opengles)
+lib{sfml-window}: SFML/Window/Win32/{hxx cxx}{*}: include = $is_windows
+lib{sfml-window}: SFML/Window/Unix/{hxx cxx}{JoystickImpl}: include = $is_linux
+lib{sfml-window}: SFML/Window/OpenBSD/{hxx cxx}{*}: include = $is_openbsd
+lib{sfml-window}: SFML/Window/FreeBSD/{hxx cxx}{*}: include = $is_freebsd
+lib{sfml-window}: SFML/Window/OSX/{h hxx cxx}{*}: include = $is_macos
+lib{sfml-window}: SFML/Window/iOS/{hxx cxx}{*}: include = $is_ios
+lib{sfml-window}: SFML/Window/Unix/{hxx cxx}{* -JoystickImpl -GlxContext}: include = $is_android
+lib{sfml-window}: SFML/Window/Android/{hxx cxx}{*}: include = $is_android
 
-if ($config.libsfml_window.use_opengles && $config.libsfml_window.platform != 'ios')
-{
-    lib{sfml-window}: SFML/Window/{hxx cxx}{EGLCheck EglContext}
-}
-
-switch $config.libsfml_window.platform
-{
-    case 'linux'
-    case 'openbsd'
-    case 'freebsd'
-    {
-        lib{sfml-window}: SFML/Window/Unix/{hxx cxx}{* -JoystickImpl -GlxContext -GlxExtensions}
-        if (!$config.libsfml_window.use_opengles)
-        {
-            lib{sfml-window}: SFML/Window/Unix/{hxx cxx}{GlxContext GlxExtensions}
-        }
-    }
-}
 
 platform_libs = # Platform specific libraries.
 platform_poptions = # Platform specific poptions.
@@ -36,7 +38,6 @@ switch $config.libsfml_window.platform
 {
     case 'windows'
     {
-        lib{sfml-window}: SFML/Window/Win32/{hxx cxx}{*}
         platform_poptions += -DUNICODE -D_UNICODE
 
         if ($cxx.target.system == 'mingw32')
@@ -46,7 +47,6 @@ switch $config.libsfml_window.platform
     }
     case 'linux'
     {
-        lib{sfml-window}: SFML/Window/Unix/{hxx cxx}{JoystickImpl}
         if ($config.libsfml_window.use_opengles)
         {
             platform_libs += -lEGL -lGLESv1_CM
@@ -55,17 +55,14 @@ switch $config.libsfml_window.platform
     }
     case 'openbsd'
     {
-        lib{sfml-window}: SFML/Window/OpenBSD/{hxx cxx}{*}
         platform_libs += -$unix_libs
     }
     case 'freebsd'
     {
-        lib{sfml-window}: SFML/Window/FreeBSD/{hxx cxx}{*}
         platform_libs += $unix_libs
     }
     case 'macos'
     {
-        lib{sfml-window}: SFML/Window/OSX/{h hxx cxx}{*}
 
         define mm: file
         mm{*}: extension = mm
@@ -171,7 +168,6 @@ switch $config.libsfml_window.platform
     }
     case 'ios'
     {
-        lib{sfml-window}: SFML/Window/iOS/{hxx cxx}{*}
         if($config.libsfml_window.use_opengles)
         {
             platform_libs += -framework OpenGLES
@@ -180,8 +176,6 @@ switch $config.libsfml_window.platform
     }
     case 'android'
     {
-        lib{sfml-window}: SFML/Window/Unix/{hxx cxx}{* -JoystickImpl -GlxContext}
-        lib{sfml-window}: SFML/Window/Android/{hxx cxx}{*}
         if($config.libsfml_window.use_opengles)
         {
             platform_libs += -lEGL -lGLESv1_CM


### PR DESCRIPTION
As suggested by the [build2 manual](https://build2.org/build2/doc/build2-build-system-manual.xhtml#intro-if-else) this PR removes conditional prerequisites and uses the `include = <expression>` construct to determine prerequisites.

@boris-kolpackov could you have a look at this? I am specifically not sure about the nasty stuff happening on MacOS in the `libsfml-window` module.

`bdep ci`: https://ci.stage.build2.org/@3199c56a-6f3d-445f-8c16-33bd864532b4